### PR TITLE
Support monolog v. 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
 matrix:
     include:
         - php: 5.3
+          dist: precise
         - php: 5.4
           env: COVERALLS=1 PHPCS=1
         - php: 5.5

--- a/README.md
+++ b/README.md
@@ -260,3 +260,8 @@ What's next?
 Symfony Users
 -------------
 You may want to use [MonologBundle](https://github.com/symfony/MonologBundle) as it integrates directly with your favorite framework.
+
+
+Under The Hood
+--------------
+Here is a [Medium post](https://medium.com/orchard-technology/enhancing-monolog-699efff1051d#.dw6qu1c2p) if you want to know more about the implementation.

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ You may want to have your Formatters and/or Handlers consume values other than v
 
     ```php
     self::$extraOptionHandlers = array(
-        '\Monolog\Formatter\LineFormatter' => array(
+        'Monolog\Formatter\LineFormatter' => array(
             'includeStacktraces' => function ($instance, $include) {
                 $instance->includeStacktraces($include);
             }

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Cascade::fileConfig($config);
 
 Then just use your logger as shown below
 ```php
-Cascade::getLogger('myApp')->info('Well, that works!');
-Cascade::getLogger('myApp')->error('Maybe not...');
+Cascade::getLogger('myLogger')->info('Well, that works!');
+Cascade::getLogger('myLogger')->error('Maybe not...');
 ```
 
 Configuring your loggers

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
     "homepage": "https://github.com/theorchard/monolog-cascade",
     "require": {
         "php": ">=5.3.9",
-        "symfony/config": "~2.7|~3.0",
-        "symfony/options-resolver": "~2.7|~3.0",
-        "symfony/serializer": "~2.7|~3.0",
-        "symfony/yaml": "~2.7|~3.0",
+        "symfony/config": "~2.7|~3.0|~4.0",
+        "symfony/options-resolver": "~2.7|~3.0|~4.0",
+        "symfony/serializer": "~2.7|~3.0|~4.0",
+        "symfony/yaml": "~2.7|~3.0|~4.0",
         "monolog/monolog": "~1.13"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "prefer-stable": true,
     "extra": {
         "branch-alias": {
-            "dev-master": "0.4.x-dev"
+            "dev-master": "0.5.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
     ],
     "homepage": "https://github.com/theorchard/monolog-cascade",
     "require": {
-        "php": "^5.3.9 || ^7.0",
+        "php": "^7.0",
         "symfony/config": "^2.7 || ^3.0 || ^4.0",
         "symfony/options-resolver": "^2.7 || ^3.0 || ^4.0",
         "symfony/serializer": "^2.7 || ^3.0 || ^4.0",
         "symfony/yaml": "^2.7 || ^3.0 || ^4.0",
-        "monolog/monolog": "^1.13"
+        "monolog/monolog": "^1.13 || ^2.0"
     },
     "autoload": {
         "psr-4": {
@@ -31,11 +31,11 @@
         }
     },
     "require-dev": {
-        "mikey179/vfsStream": "^1.6",
-        "phpunit/phpcov": "^2.0",
-        "phpunit/phpunit": "^4.8",
-        "satooshi/php-coveralls": "^1.0",
-        "squizlabs/php_codesniffer": "^2.5"
+        "mikey179/vfsstream": "^1.6",
+        "phpunit/phpcov": "~4.0.5",
+        "phpunit/phpunit": "~6.5.14",
+        "satooshi/php-coveralls": "~2.2",
+        "squizlabs/php_codesniffer": "~3.0"
     },
     "prefer-stable": true,
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,10 @@
     "homepage": "https://github.com/theorchard/monolog-cascade",
     "require": {
         "php": ">=5.3.9",
-        "symfony/config": "~2.7",
-        "symfony/options-resolver": "~2.7",
-        "symfony/yaml": "~2.7",
+        "symfony/config": "~2.7|~3.0|~3.1",
+        "symfony/options-resolver": "~2.7|~3.0|~3.1",
+        "symfony/serializer": "~2.7|~3.0|~3.1",
+        "symfony/yaml": "~2.7|~3.0|~3.1",
         "monolog/monolog": "~1.13"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "php": ">=5.3.9",
         "symfony/config": "~2.7",
         "symfony/options-resolver": "~2.7",
-        "symfony/serializer": "~2.7",
         "symfony/yaml": "~2.7",
         "monolog/monolog": "~1.13"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
     "homepage": "https://github.com/theorchard/monolog-cascade",
     "require": {
         "php": ">=5.3.9",
-        "symfony/config": "~2.7|~3.0|~3.1",
-        "symfony/options-resolver": "~2.7|~3.0|~3.1",
-        "symfony/serializer": "~2.7|~3.0|~3.1",
-        "symfony/yaml": "~2.7|~3.0|~3.1",
+        "symfony/config": "~2.7|~3.0",
+        "symfony/options-resolver": "~2.7|~3.0",
+        "symfony/serializer": "~2.7|~3.0",
+        "symfony/yaml": "~2.7|~3.0",
         "monolog/monolog": "~1.13"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
     ],
     "homepage": "https://github.com/theorchard/monolog-cascade",
     "require": {
-        "php": ">=5.3.9",
-        "symfony/config": "~2.7|~3.0|~4.0",
-        "symfony/options-resolver": "~2.7|~3.0|~4.0",
-        "symfony/serializer": "~2.7|~3.0|~4.0",
-        "symfony/yaml": "~2.7|~3.0|~4.0",
-        "monolog/monolog": "~1.13"
+        "php": "^5.3.9 || ^7.0",
+        "symfony/config": "^2.7 || ^3.0 || ^4.0",
+        "symfony/options-resolver": "^2.7 || ^3.0 || ^4.0",
+        "symfony/serializer": "^2.7 || ^3.0 || ^4.0",
+        "symfony/yaml": "^2.7 || ^3.0 || ^4.0",
+        "monolog/monolog": "^1.13"
     },
     "autoload": {
         "psr-4": {
@@ -31,11 +31,11 @@
         }
     },
     "require-dev": {
-        "mikey179/vfsStream": "~1.6",
-        "phpunit/phpcov": "~2.0",
-        "phpunit/phpunit": "~4.8",
-        "satooshi/php-coveralls": "~1.0",
-        "squizlabs/php_codesniffer": "~2.5"
+        "mikey179/vfsStream": "^1.6",
+        "phpunit/phpcov": "^2.0",
+        "phpunit/phpunit": "^4.8",
+        "satooshi/php-coveralls": "^1.0",
+        "squizlabs/php_codesniffer": "^2.5"
     },
     "prefer-stable": true,
     "extra": {

--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -10,20 +10,18 @@
  */
 namespace Cascade;
 
-use Cascade\Config;
-use Cascade\Config\ConfigLoader;
-use Monolog\Handler\HandlerInterface;
 use Monolog\Logger;
 use Monolog\Registry;
 
+use Cascade\Config;
+use Cascade\Config\ConfigLoader;
+
 /**
  * Module class that manages Monolog Logger object
+ * @see Monolog\Logger
+ * @see Monolog\Registry
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
- *
- * @see    \Monolog\Logger
- * @see    \Monolog\Registry
- *
  */
 class Cascade
 {
@@ -36,17 +34,16 @@ class Cascade
 
     /**
      * Create a new Logger object and push it to the registry
-     *
      * @see Monolog\Logger::__construct
      *
-     * @param string             $name       The logging channel
-     * @param HandlerInterface[] $handlers   Optional stack of handlers, the first one in the array is called first,
-     *                                       etc.
-     * @param callable[]        $processors Optional array of processors
+     * @throws \InvalidArgumentException if no name is given
      *
-     * @throws \InvalidArgumentException: if no name is given
+     * @param string $name The logging channel
+     * @param Monolog\Handler\HandlerInterface[] $handlers Optional stack of handlers, the first
+     * one in the array is called first, etc.
+     * @param callable[] $processors Optional array of processors
      *
-     * @return Logger newly created Logger
+     * @return Logger Newly created Logger
      */
     public static function createLogger(
         $name,
@@ -93,7 +90,7 @@ class Cascade
     /**
      * Return the config options
      *
-     * @return array array with configuration options
+     * @return array Array with configuration options
      */
     public static function getConfig()
     {
@@ -103,7 +100,7 @@ class Cascade
     /**
      * Load configuration options from a file or a string
      *
-     * @param string $resource path to config file or string or array
+     * @param string $resource Path to config file or string or array
      */
     public static function fileConfig($resource)
     {

--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -10,16 +10,16 @@
  */
 namespace Cascade;
 
+use Monolog\Handler\HandlerInterface;
 use Monolog\Logger;
 use Monolog\Registry;
 
-use Cascade\Config;
 use Cascade\Config\ConfigLoader;
 
 /**
  * Module class that manages Monolog Logger object
- * @see Monolog\Logger
- * @see Monolog\Registry
+ * @see Logger
+ * @see Registry
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
@@ -34,12 +34,12 @@ class Cascade
 
     /**
      * Create a new Logger object and push it to the registry
-     * @see Monolog\Logger::__construct
+     * @see Logger::__construct
      *
      * @throws \InvalidArgumentException if no name is given
      *
      * @param string $name The logging channel
-     * @param Monolog\Handler\HandlerInterface[] $handlers Optional stack of handlers, the first
+     * @param HandlerInterface[] $handlers Optional stack of handlers, the first
      * one in the array is called first, etc.
      * @param callable[] $processors Optional array of processors
      *
@@ -90,7 +90,7 @@ class Cascade
     /**
      * Return the config options
      *
-     * @return array Array with configuration options
+     * @return Config Array with configuration options
      */
     public static function getConfig()
     {

--- a/src/Cascade.php
+++ b/src/Cascade.php
@@ -98,14 +98,36 @@ class Cascade
     }
 
     /**
-     * Load configuration options from a file or a string
+     * Load configuration options from a file, a JSON or Yaml string or an array.
      *
-     * @param string $resource Path to config file or string or array
+     * @param string|array $resource Path to config file or configuration as string or array
      */
     public static function fileConfig($resource)
     {
         self::$config = new Config($resource, new ConfigLoader());
         self::$config->load();
         self::$config->configure();
+    }
+
+    /**
+     * Load configuration options from a JSON or Yaml string. Alias of fileConfig.
+     * @see fileConfig
+     *
+     * @param string $configString Configuration in string form
+     */
+    public static function loadConfigFromString($configString)
+    {
+        self::fileConfig($configString);
+    }
+
+    /**
+     * Load configuration options from an array. Alias of fileConfig.
+     * @see fileConfig
+     *
+     * @param array $configArray Configuration in array form
+     */
+    public static function loadConfigFromArray($configArray)
+    {
+        self::fileConfig($configArray);
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -10,7 +10,7 @@
  */
 namespace Cascade;
 
-use Monolog\Registry;
+use Monolog;
 
 use Cascade\Config\ConfigLoader;
 use Cascade\Config\Loader\ClassLoader\FormatterLoader;
@@ -99,7 +99,7 @@ class Config
         }
 
         if ($this->options['disable_existing_loggers']) {
-            Registry::clear();
+            Monolog\Registry::clear();
         }
 
         if (isset($this->options['formatters'])) {

--- a/src/Config.php
+++ b/src/Config.php
@@ -10,14 +10,13 @@
  */
 namespace Cascade;
 
+use Monolog\Registry;
+
 use Cascade\Config\ConfigLoader;
 use Cascade\Config\Loader\ClassLoader\FormatterLoader;
 use Cascade\Config\Loader\ClassLoader\HandlerLoader;
 use Cascade\Config\Loader\ClassLoader\LoggerLoader;
 use Cascade\Config\Loader\ClassLoader\ProcessorLoader;
-use Monolog\Formatter\FormatterInterface;
-use Monolog\Handler\HandlerInterface;
-use Monolog\Registry;
 
 /**
  * Config class that takes a config resource (file, JSON, Yaml, etc.) and configure Loggers with
@@ -29,7 +28,7 @@ class Config
 {
     /**
      * Input from user. This is either a file path, a string or an array
-     * @var string | array
+     * @var string|array
      */
     protected $input = null;
 
@@ -41,13 +40,13 @@ class Config
 
     /**
      * Array of Formatter objects
-     * @var FormatterInterface[]
+     * @var Monolog\Formatter\FormatterInterface[]
      */
     protected $formatters = array();
 
     /**
      * Array of Handler objects
-     * @var HandlerInterface[]
+     * @var Monolog\Handler\HandlerInterface[]
      */
     protected $handlers = array();
 
@@ -59,7 +58,7 @@ class Config
 
     /**
      * Array of logger objects
-     * @var \Monolog\Logger[]
+     * @var Monolog\Logger[]
      */
     protected $loggers = array();
 
@@ -72,7 +71,7 @@ class Config
     /**
      * Instantiate a Config object
      *
-     * @param string | array $input user input
+     * @param string|array $input User input
      * @param ConfigLoader $loader Config loader object
      */
     public function __construct($input, ConfigLoader $loader)
@@ -126,7 +125,8 @@ class Config
 
     /**
      * Configure the formatters
-     * @param  array $formatters array of formatter options
+     *
+     * @param  array $formatters Array of formatter options
      */
     protected function configureFormatters(array $formatters = array())
     {
@@ -138,7 +138,8 @@ class Config
 
     /**
      * Configure the handlers
-     * @param  array $handlers array of handler options
+     *
+     * @param  array $handlers Array of handler options
      */
     protected function configureHandlers(array $handlers)
     {
@@ -151,7 +152,7 @@ class Config
     /**
      * Configure the processors
      *
-     * @param  array $processors array of processor options
+     * @param  array $processors Array of processor options
      */
     protected function configureProcessors(array $processors)
     {
@@ -164,7 +165,7 @@ class Config
     /**
      * Configure the loggers
      *
-     * @param  array $loggers array of logger options
+     * @param  array $loggers Array of logger options
      */
     protected function configureLoggers(array $loggers)
     {

--- a/src/Config/ConfigLoader.php
+++ b/src/Config/ConfigLoader.php
@@ -14,22 +14,22 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\DelegatingLoader;
 use Symfony\Component\Config\Loader\LoaderResolver;
 
-use Cascade\Config\Loader\PhpArray as ArrayLoader;
-use Cascade\Config\Loader\FileLoader\PhpArray as ArrayFromFileLoader;
 use Cascade\Config\Loader\FileLoader\Json as JsonLoader;
+use Cascade\Config\Loader\FileLoader\PhpArray as ArrayFromFileLoader;
 use Cascade\Config\Loader\FileLoader\Yaml as YamlLoader;
+use Cascade\Config\Loader\PhpArray as ArrayLoader;
 
 /**
  * Loader class that loads Yaml, JSON and array from various resources (file, php array, string)
+ * @see DelegatingLoader
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
- * @see    DelegatingLoader
  */
 class ConfigLoader extends DelegatingLoader
 {
     /**
      * Locator
-     * @var \Symfony\Component\Config\FileLocator
+     * @var FileLocator
      */
     protected $locator = null;
 
@@ -56,10 +56,10 @@ class ConfigLoader extends DelegatingLoader
     /**
      * Loads a configuration resource: file, array, string
      *
-     * @param mixed $resource resource to load
-     * @param mixed $type not used
+     * @param mixed $resource Resource to load
+     * @param string|null $type Not used
      *
-     * @return array array of config options
+     * @return array Array of config options
      */
     public function load($resource, $type = null)
     {

--- a/src/Config/Loader/ClassLoader.php
+++ b/src/Config/Loader/ClassLoader.php
@@ -10,7 +10,6 @@
  */
 namespace Cascade\Config\Loader;
 
-use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 
 use Cascade\Config\Loader\ClassLoader\Resolver\ConstructorResolver;
@@ -29,6 +28,7 @@ use Cascade\Config\Loader\ClassLoader\Resolver\ExtraOptionsResolver;
  * For the latter you need to make sure there is a handler defined for that option
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ * @author Dom Morgan <dom@d3r.com>
  */
 class ClassLoader
 {
@@ -69,7 +69,7 @@ class ClassLoader
     /**
      * Constructor
      *
-     * @param array $options array of options
+     * @param array $options Array of options
      * The option array might look like:
      *     array(
      *         'class' => 'Some\Class',
@@ -101,8 +101,6 @@ class ClassLoader
     /**
      * Recursively loads objects into any of the rawOptions that represent
      * a class
-     *
-     * @author Dom Morgan <dom@d3r.com>
      */
     protected function loadChildClasses()
     {
@@ -120,8 +118,9 @@ class ClassLoader
     /**
      * Return option values indexed by name using camelCased keys
      *
-     * @param  array  $options array of options
-     * @return mixed[] array of options indexed by (camelCased) name
+     * @param  array  $options Array of options
+     *
+     * @return mixed[] Array of options indexed by (camelCased) name
      */
     public static function optionsToCamelCase(array $options)
     {
@@ -145,7 +144,7 @@ class ClassLoader
      * Extra options are those that are not in the contructor. The constructor arguments determine
      * what goes into which bucket
      *
-     * @return array array of constructorOptions and extraOptions
+     * @return array Array of constructorOptions and extraOptions
      */
     private function resolveOptions()
     {
@@ -178,7 +177,7 @@ class ClassLoader
      * Instantiate the reflected object using the parsed contructor args and set
      * extra options if any
      *
-     * @return mixed instance of the reflected object
+     * @return mixed Instance of the reflected object
      */
     public function load()
     {
@@ -196,7 +195,8 @@ class ClassLoader
      * Indicates whether or not an option is supported by the loader
      *
      * @param  string $extraOptionName Option name
-     * @return boolean whether or not an option is supported by the loader
+     *
+     * @return boolean Whether or not an option is supported by the loader
      */
     public function canHandle($extraOptionName)
     {
@@ -209,6 +209,7 @@ class ClassLoader
      * Get the corresponding handler for a given option
      *
      * @param  string $extraOptionName Option name
+     *
      * @return \Closure|null Corresponding Closure object or null if not found
      */
     public function getExtraOptionsHandler($extraOptionName)

--- a/src/Config/Loader/ClassLoader.php
+++ b/src/Config/Loader/ClassLoader.php
@@ -10,10 +10,9 @@
  */
 namespace Cascade\Config\Loader;
 
-use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
-
 use Cascade\Config\Loader\ClassLoader\Resolver\ConstructorResolver;
 use Cascade\Config\Loader\ClassLoader\Resolver\ExtraOptionsResolver;
+use Cascade\Util;
 
 /**
  * Class Loader. Instantiate an object given a set of options. The option might look like:
@@ -127,10 +126,8 @@ class ClassLoader
         $optionsByName = array();
 
         if (count($options)) {
-            $nameConverter = new CamelCaseToSnakeCaseNameConverter();
-
             foreach ($options as $name => $value) {
-                $optionsByName[$nameConverter->denormalize($name)] = $value;
+                $optionsByName[Util::snakeToCamelCase($name)] = $value;
             }
         }
 

--- a/src/Config/Loader/ClassLoader/FormatterLoader.php
+++ b/src/Config/Loader/ClassLoader/FormatterLoader.php
@@ -10,7 +10,7 @@
  */
 namespace Cascade\Config\Loader\ClassLoader;
 
-use Monolog\Formatter\LineFormatter;
+use Monolog;
 
 use Cascade\Config\Loader\ClassLoader;
 
@@ -63,7 +63,7 @@ class FormatterLoader extends ClassLoader
     {
         self::$extraOptionHandlers = array(
             'Monolog\Formatter\LineFormatter' => array(
-                'includeStacktraces' => function (LineFormatter $instance, $include) {
+                'includeStacktraces' => function (Monolog\Formatter\LineFormatter $instance, $include) {
                     $instance->includeStacktraces($include);
                 }
             )

--- a/src/Config/Loader/ClassLoader/FormatterLoader.php
+++ b/src/Config/Loader/ClassLoader/FormatterLoader.php
@@ -10,8 +10,9 @@
  */
 namespace Cascade\Config\Loader\ClassLoader;
 
-use Cascade\Config\Loader\ClassLoader;
 use Monolog\Formatter\LineFormatter;
+
+use Cascade\Config\Loader\ClassLoader;
 
 /**
  * Formatter Loader. Loads the Formatter options, validate them and instantiates
@@ -26,7 +27,7 @@ class FormatterLoader extends ClassLoader
     /**
      * Default formatter class to use if none is provided in the option array
      */
-    const DEFAULT_CLASS = '\Monolog\Formatter\LineFormatter';
+    const DEFAULT_CLASS = 'Monolog\Formatter\LineFormatter';
 
     /**
      * Constructor
@@ -61,7 +62,7 @@ class FormatterLoader extends ClassLoader
     public static function initExtraOptionsHandlers()
     {
         self::$extraOptionHandlers = array(
-            '\Monolog\Formatter\LineFormatter' => array(
+            'Monolog\Formatter\LineFormatter' => array(
                 'includeStacktraces' => function (LineFormatter $instance, $include) {
                     $instance->includeStacktraces($include);
                 }

--- a/src/Config/Loader/ClassLoader/HandlerLoader.php
+++ b/src/Config/Loader/ClassLoader/HandlerLoader.php
@@ -34,7 +34,7 @@ class HandlerLoader extends ClassLoader
     /**
      * Constructor
      * @see ClassLoader::__construct
-     * @see Monolog\Handler classes for handler options
+     * @see \Monolog\Handler classes for handler options
      *
      * @param array $handlerOptions Handler options
      * @param FormatterInterface[] $formatters Array of formatter to pick from

--- a/src/Config/Loader/ClassLoader/HandlerLoader.php
+++ b/src/Config/Loader/ClassLoader/HandlerLoader.php
@@ -11,10 +11,10 @@
 namespace Cascade\Config\Loader\ClassLoader;
 
 use Monolog\Formatter\FormatterInterface;
-
-use Cascade\Config\Loader\ClassLoader;
 use Monolog\Handler\HandlerInterface;
 use Monolog\Handler\LogglyHandler;
+
+use Cascade\Config\Loader\ClassLoader;
 
 /**
  * Handler Loader. Loads the Handler options, validate them and instantiates
@@ -29,7 +29,7 @@ class HandlerLoader extends ClassLoader
     /**
      * Default handler class to use if none is provided in the option array
      */
-    const DEFAULT_CLASS = '\Monolog\Handler\StreamHandler';
+    const DEFAULT_CLASS = 'Monolog\Handler\StreamHandler';
 
     /**
      * Constructor
@@ -37,7 +37,7 @@ class HandlerLoader extends ClassLoader
      * @see Monolog\Handler classes for handler options
      *
      * @param array $handlerOptions Handler options
-     * @param \Monolog\Formatter\FormatterInterface[] $formatters Array of formatter to pick from
+     * @param FormatterInterface[] $formatters Array of formatter to pick from
      * @param callable[] $processors Array of processors to pick from
      * @param callable[] $handlers Array of handlers to pick from
      */
@@ -65,7 +65,7 @@ class HandlerLoader extends ClassLoader
      * @throws \InvalidArgumentException
      *
      * @param  array &$handlerOptions Handler options
-     * @param  \Monolog\Formatter\FormatterInterface[] $formatters Array of formatter to pick from
+     * @param  FormatterInterface[] $formatters Array of formatter to pick from
      */
     private function populateFormatters(array &$handlerOptions, array $formatters)
     {

--- a/src/Config/Loader/ClassLoader/LoggerLoader.php
+++ b/src/Config/Loader/ClassLoader/LoggerLoader.php
@@ -11,7 +11,8 @@
 namespace Cascade\Config\Loader\ClassLoader;
 
 use Cascade\Cascade;
-use Cascade\Config\Loader\ClassLoader;
+
+use Monolog;
 
 /**
  * Logger Loader. Instantiate a Logger and set passed in handlers and processors if any

--- a/src/Config/Loader/ClassLoader/LoggerLoader.php
+++ b/src/Config/Loader/ClassLoader/LoggerLoader.php
@@ -29,7 +29,7 @@ class LoggerLoader
 
     /**
      * Array of handlers
-     * @var \Monolog\Handler\HandlerInterface[]
+     * @var Monolog\Handler\HandlerInterface[]
      */
     protected $handlers = array();
 
@@ -41,7 +41,7 @@ class LoggerLoader
 
     /**
      * Logger
-     * @var \Monolog\Logger
+     * @var Monolog\Logger
      */
     protected $logger = null;
 
@@ -50,7 +50,7 @@ class LoggerLoader
      *
      * @param string $loggerName Name of the logger
      * @param array  $loggerOptions Array of logger options
-     * @param \Monolog\Handler\HandlerInterface[] $handlers Array of Monolog handlers
+     * @param Monolog\Handler\HandlerInterface[] $handlers Array of Monolog handlers
      * @param callable[] $processors Array of processors
      */
     public function __construct(
@@ -73,9 +73,10 @@ class LoggerLoader
      *
      * @throws \InvalidArgumentException if a requested handler is not available in $handlers
      *
-     * @param  array $loggerOptions array of logger options
-     * @param  \Monolog\Handler\HandlerInterface[] $handlers Available Handlers to resolve against
-     * @return \Monolog\Handler\HandlerInterface[] Array of Monolog handlers
+     * @param  array $loggerOptions Array of logger options
+     * @param  Monolog\Handler\HandlerInterface[] $handlers Available Handlers to resolve against
+     *
+     * @return Monolog\Handler\HandlerInterface[] Array of Monolog handlers
      */
     public function resolveHandlers(array $loggerOptions, array $handlers)
     {
@@ -110,8 +111,9 @@ class LoggerLoader
      *
      * @throws \InvalidArgumentException if a requested processor is not available in $processors
      *
-     * @param  array $loggerOptions array of logger options
+     * @param  array $loggerOptions Array of logger options
      * @param  callable[] $processors Available Processors to resolve against
+     *
      * @return callable[] Array of Monolog processors
      */
     public function resolveProcessors(array $loggerOptions, $processors)
@@ -144,7 +146,7 @@ class LoggerLoader
     /**
      * Add handlers to the Logger
      *
-     * @param \Monolog\Handler\HandlerInterface[] Array of Monolog handlers
+     * @param Monolog\Handler\HandlerInterface[] Array of Monolog handlers
      */
     private function addHandlers(array $handlers)
     {
@@ -170,7 +172,7 @@ class LoggerLoader
     /**
      * Return the instantiated Logger object based on its name
      *
-     * @return \Monolog\Logger Logger object
+     * @return Monolog\Logger Logger object
      */
     public function load()
     {

--- a/src/Config/Loader/ClassLoader/ProcessorLoader.php
+++ b/src/Config/Loader/ClassLoader/ProcessorLoader.php
@@ -12,6 +12,8 @@ namespace Cascade\Config\Loader\ClassLoader;
 
 use Cascade\Config\Loader\ClassLoader;
 
+use Monolog;
+
 /**
  * Processor Loader. Loads the Processor options, validate them and instantiates
  * a Processor object (implementing Monolog\Processor\ProcessorInterface) with all

--- a/src/Config/Loader/ClassLoader/ProcessorLoader.php
+++ b/src/Config/Loader/ClassLoader/ProcessorLoader.php
@@ -19,6 +19,7 @@ use Cascade\Config\Loader\ClassLoader;
  * @see ClassLoader
  *
  * @author Kate Burdon <kburdon@tableau.com>
+ * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
 class ProcessorLoader extends ClassLoader
 {
@@ -28,7 +29,7 @@ class ProcessorLoader extends ClassLoader
      * @see Monolog\Handler classes for handler options
      *
      * @param array $processorOptions Processor options
-     * @param \Monolog\Processor\ProcessorInterface[] $processors Array of processors to pick from
+     * @param Monolog\Processor\ProcessorInterface[] $processors Array of processors to pick from
      */
     public function __construct(array &$processorOptions, array $processors = array())
     {

--- a/src/Config/Loader/ClassLoader/Resolver/ConstructorResolver.php
+++ b/src/Config/Loader/ClassLoader/Resolver/ConstructorResolver.php
@@ -23,14 +23,12 @@ class ConstructorResolver
 {
     /**
      * Reflection class for which you want to resolve constructor options
-     *
      * @var \ReflectionClass
      */
     protected $reflected = null;
 
     /**
      * Registry of resolvers
-     *
      * @var array
      */
     private static $resolvers = array();
@@ -114,8 +112,9 @@ class ConstructorResolver
      * the option values passed in. We assume the passed in array has been resolved already.
      * i.e. That the arg name has an entry in the option array.
      *
-     * @param  array $hashOfOptions array of options
-     * @return array array of ordered args
+     * @param  array $hashOfOptions Array of options
+     *
+     * @return array Array of ordered args
      */
     public function hashToArgsArray($hashOfOptions)
     {
@@ -136,7 +135,8 @@ class ConstructorResolver
      *         'someParam' => 'def',
      *         'someOtherParam' => 'sdsad'
      *     )
-     * @return array array of resolved ordered args
+     *
+     * @return array Array of resolved ordered args
      */
     public function resolve(array $options)
     {

--- a/src/Config/Loader/ClassLoader/Resolver/ConstructorResolver.php
+++ b/src/Config/Loader/ClassLoader/Resolver/ConstructorResolver.php
@@ -10,8 +10,8 @@
  */
 namespace Cascade\Config\Loader\ClassLoader\Resolver;
 
+use Cascade\Util;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 
 /**
  * Constructor Resolver. Pull args from the contructor and set up an option
@@ -61,12 +61,12 @@ class ConstructorResolver
     public function initConstructorArgs()
     {
         $constructor = $this->reflected->getConstructor();
-        $nameConverter = new CamelCaseToSnakeCaseNameConverter();
 
         if (!is_null($constructor)) {
             // Index parameters by their names
             foreach ($constructor->getParameters() as $param) {
-                $this->constructorArgs[$nameConverter->denormalize($param->getName())] = $param;
+                $name = Util::snakeToCamelCase($param->getName());
+                $this->constructorArgs[$name] = $param;
             }
         }
     }

--- a/src/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolver.php
+++ b/src/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolver.php
@@ -98,7 +98,7 @@ class ExtraOptionsResolver
     /**
      * Configure options for the provided OptionResolver to match extra params requirements
      *
-     * @param  OptionsResolver $optionsResolver OptionResolver to configure
+     * @param  OptionsResolver $resolver OptionResolver to configure
      * @param  ClassLoader|null $classLoader Optional class loader if you want to use custom
      * handlers for some of the extra options
      */

--- a/src/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolver.php
+++ b/src/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolver.php
@@ -24,14 +24,12 @@ class ExtraOptionsResolver
 {
     /**
      * Reflection class for which you want to resolve extra options
-     *
      * @var \ReflectionClass
      */
     protected $reflected = null;
 
     /**
      * Registry of resolvers
-     *
      * @var OptionsResolver[]
      */
     private static $resolvers = array();
@@ -57,6 +55,7 @@ class ExtraOptionsResolver
 
     /**
      * Set the parameters we want to resolve against
+     *
      * @param array $params Associative array of extra parameters we want to resolve against
      */
     public function setParams(array $params = array())
@@ -88,7 +87,8 @@ class ExtraOptionsResolver
      * Generate a unique hash based on the keys of the extra params
      *
      * @param  array $params: array of parameters
-     * @return string unique MD5 hash
+     *
+     * @return string Unique MD5 hash
      */
     public static function generateParamsHashKey($params)
     {
@@ -133,6 +133,7 @@ class ExtraOptionsResolver
      * @param  array $options Array of option values
      * @param  ClassLoader|null $classLoader Optional class loader if you want to use custom
      * handlers to resolve the extra options
+     *
      * @return array Array of resolved options
      */
     public function resolve($options, ClassLoader $classLoader = null)

--- a/src/Config/Loader/FileLoader/FileLoaderAbstract.php
+++ b/src/Config/Loader/FileLoader/FileLoaderAbstract.php
@@ -23,10 +23,12 @@ abstract class FileLoaderAbstract extends FileLoader
 
     /**
      * Read from a file or string
+     *
      * @throws \RuntimeException if the file is not readable
      *
      * @param  string $input Filepath or string
-     * @return string return a string
+     *
+     * @return string Return a string from read file or directly from $input
      */
     public function readFrom($input)
     {
@@ -48,7 +50,8 @@ abstract class FileLoaderAbstract extends FileLoader
      * Test if a given resource is a file name or a file path
      *
      * @param  string $resource Plain string or file path
-     * @return boolean whether or not the resource is a file
+     *
+     * @return boolean Whether or not the resource is a file
      */
     public function isFile($resource)
     {
@@ -59,7 +62,8 @@ abstract class FileLoaderAbstract extends FileLoader
      * Validate a file extension against a list of provided valid extensions
      *
      * @param  string $filepath file path of the file we want to check
-     * @return boolean whether or no the extension is valid
+     *
+     * @return boolean Whether or not the extension is valid
      */
     public function validateExtension($filepath)
     {
@@ -72,7 +76,7 @@ abstract class FileLoaderAbstract extends FileLoader
      * @param  array $array Array we want the section from
      * @param  string $section Section name (key)
      *
-     * @return array | mixed   return the section of an array or just a value
+     * @return array|mixed Return the section of an array or just a value
      */
     public function getSectionOf($array, $section = '')
     {

--- a/src/Config/Loader/FileLoader/Json.php
+++ b/src/Config/Loader/FileLoader/Json.php
@@ -56,7 +56,7 @@ class Json extends FileLoaderAbstract
     }
 
     /**
-     * Return whether or not the passed in resrouce is supported by this loader
+     * Return whether or not the passed in resource is supported by this loader
      *
      * @param  string $resource Plain string or filepath
      * @param  string $type Not used

--- a/src/Config/Loader/FileLoader/Json.php
+++ b/src/Config/Loader/FileLoader/Json.php
@@ -28,8 +28,9 @@ class Json extends FileLoaderAbstract
      * Load a JSON string/file
      *
      * @param  string $resource JSON string or file path to a JSON file
-     * @param  string|null $type This is not used.
-     * @return array array containing data from the parsed JSON string or file
+     * @param  string|null $type Not used.
+     *
+     * @return array Array containing data from the parsed JSON string or file
      */
     public function load($resource, $type = null)
     {
@@ -42,8 +43,9 @@ class Json extends FileLoaderAbstract
      * json_decode (which is much more expensive). If the json is invalid, it will throw an
      * exception when we actually load it.
      *
-     * @param  string  $string String to evaluate
-     * @return boolean whether or not the passed string is meant to be a JSON string
+     * @param  string $string String to evaluate
+     *
+     * @return boolean Whether or not the passed string is meant to be a JSON string
      */
     private function isJson($string)
     {
@@ -56,9 +58,10 @@ class Json extends FileLoaderAbstract
     /**
      * Return whether or not the passed in resrouce is supported by this loader
      *
-     * @param  string $resource plain string or filepath
-     * @param  string $type not used
-     * @return boolean whether or not the passed in resource is supported by this loader
+     * @param  string $resource Plain string or filepath
+     * @param  string $type Not used
+     *
+     * @return boolean Whether or not the passed in resource is supported by this loader
      */
     public function supports($resource, $type = null)
     {

--- a/src/Config/Loader/FileLoader/PhpArray.php
+++ b/src/Config/Loader/FileLoader/PhpArray.php
@@ -24,9 +24,10 @@ class PhpArray extends FileLoaderAbstract
     /**
      * Load a PHP file
      *
-     * @param  string $resource  File path to a PHP file that returns an array
+     * @param  string $resource File path to a PHP file that returns an array
      * @param  string|null $type This is not used
-     * @return array             array containing data from the PHP file
+     *
+     * @return array Array containing data from the PHP file
      */
     public function load($resource, $type = null)
     {
@@ -46,9 +47,10 @@ class PhpArray extends FileLoaderAbstract
      * /!\ This does not verify that the php file returns a valid array. An exception
      * will be thrown when it is loaded if that is not the case.
      *
-     * @param  string $resource filepath
-     * @param  string $type     not used
-     * @return boolean          whether or not the passed in resource is supported by this loader
+     * @param  string $resource Filepath
+     * @param  string $type Not used
+     *
+     * @return boolean Whether or not the passed in resource is supported by this loader
      */
     public function supports($resource, $type = null)
     {

--- a/src/Config/Loader/FileLoader/Yaml.php
+++ b/src/Config/Loader/FileLoader/Yaml.php
@@ -26,15 +26,16 @@ class Yaml extends FileLoaderAbstract
      */
     public static $validExtensions = array(
         'yaml', // official extension
-        'yml' // but everybody uses that one
+        'yml'   // but everybody uses that one
     );
 
     /**
      * Load a Yaml string/file
      *
-     * @param  string $resource  Yaml string or file path to a Yaml file
-     * @param  string|null $type This is not used
-     * @return array             array containing data from the parse Yaml string or file
+     * @param  string $resource Yaml string or file path to a Yaml file
+     * @param  string|null $type Not used
+     *
+     * @return array Array containing data from the parse Yaml string or file
      */
     public function load($resource, $type = null)
     {
@@ -45,9 +46,10 @@ class Yaml extends FileLoaderAbstract
      * Return whether or not the resource passed in is supported by this loader
      * /!\ This does not validate Yaml content. The parser will raise an exception in that case
      *
-     * @param  string $resource plain string or filepath
-     * @param  string $type     not used
-     * @return boolean          whether or not the passed in resrouce is supported by this loader
+     * @param  string $resource Plain string or filepath
+     * @param  string $type Not used
+     *
+     * @return boolean Whether or not the passed in resrouce is supported by this loader
      */
     public function supports($resource, $type = null)
     {

--- a/src/Config/Loader/PhpArray.php
+++ b/src/Config/Loader/PhpArray.php
@@ -24,7 +24,8 @@ class PhpArray extends Loader
      * Loads an array
      *
      * @param  array $array Array to load
-     * @param  string|null $type This is not used.
+     * @param  string|null $type Not used
+     *
      * @return array The passed in array
      */
     public function load($array, $type = null)
@@ -35,9 +36,10 @@ class PhpArray extends Loader
     /**
      * Return whether or not the passed in resource is supported by this loader
      *
-     * @param  string $resource plain string or filepath
-     * @param  string $type     resource type
-     * @return boolean          whether or not the passed in resrouce is supported by this loader
+     * @param  string $resource Plain string or filepath
+     * @param  string|null $type Not used
+     *
+     * @return boolean Whether or not the passed in resource is supported by this loader
      */
     public function supports($resource, $type = null)
     {

--- a/src/Util.php
+++ b/src/Util.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Cascade;
+
+/**
+ * Class Util
+ *
+ * @package Cascade
+ */
+class Util
+{
+
+    /**
+     * Convert a string from snake_case to camelCase.
+     *
+     * If the input is not a string, null is returned.
+     *
+     * @param string $input Input snake_case string
+     * @return null|string Output camelCase string
+     */
+    public static function snakeToCamelCase($input)
+    {
+        if (!is_string($input)) {
+            return null;
+        }
+
+        $output = preg_replace_callback('/(^|_)+(.)/', function ($match) {
+            return strtoupper($match[2]);
+        }, $input);
+
+        return lcfirst($output);
+    }
+}

--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -12,6 +12,7 @@ namespace Cascade\Tests;
 
 use Monolog\Logger;
 use Monolog\Registry;
+use PHPUnit\Framework\TestCase;
 
 use Cascade\Cascade;
 
@@ -20,7 +21,7 @@ use Cascade\Cascade;
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class CascadeTest extends \PHPUnit_Framework_TestCase
+class CascadeTest extends TestCase
 {
     public function teardown()
     {

--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -14,7 +14,6 @@ use Monolog\Logger;
 use Monolog\Registry;
 
 use Cascade\Cascade;
-use Cascade\Tests\Fixtures;
 
 /**
  * Class CascadeTest
@@ -49,11 +48,11 @@ class CascadeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testRegistryWithInvalidName()
     {
-        $logger = Cascade::getLogger(null);
+        Cascade::getLogger(null);
     }
 
     public function testFileConfig()

--- a/tests/CascadeTest.php
+++ b/tests/CascadeTest.php
@@ -57,8 +57,29 @@ class CascadeTest extends \PHPUnit_Framework_TestCase
 
     public function testFileConfig()
     {
+        $filePath = Fixtures::getPhpArrayConfigFile();
+        Cascade::fileConfig($filePath);
+        $this->assertInstanceOf('Cascade\Config', Cascade::getConfig());
+    }
+
+    public function testLoadConfigFromArray()
+    {
         $options = Fixtures::getPhpArrayConfig();
-        Cascade::fileConfig($options);
+        Cascade::loadConfigFromArray($options);
+        $this->assertInstanceOf('Cascade\Config', Cascade::getConfig());
+    }
+
+    public function testLoadConfigFromStringWithJson()
+    {
+        $jsonConfig = Fixtures::getJsonConfig();
+        Cascade::loadConfigFromString($jsonConfig);
+        $this->assertInstanceOf('Cascade\Config', Cascade::getConfig());
+    }
+
+    public function testLoadConfigFromStringWithYaml()
+    {
+        $yamlConfig = Fixtures::getYamlConfig();
+        Cascade::loadConfigFromString($yamlConfig);
         $this->assertInstanceOf('Cascade\Config', Cascade::getConfig());
     }
 }

--- a/tests/Config/ConfigLoaderTest.php
+++ b/tests/Config/ConfigLoaderTest.php
@@ -12,13 +12,14 @@ namespace Cascade\Tests\Config;
 
 use Cascade\Config\ConfigLoader;
 use Cascade\Tests\Fixtures;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ConfigLoaderTest
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class ConfigLoaderTest extends \PHPUnit_Framework_TestCase
+class ConfigLoaderTest extends TestCase
 {
     /**
      * Loader to test against

--- a/tests/Config/Loader/ClassLoader/FormatterLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/FormatterLoaderTest.php
@@ -43,8 +43,8 @@ class FormatterLoaderTest extends \PHPUnit_Framework_TestCase
      *
      * @param  string $class Class name the handler applies to
      * @param  string $optionName Option name
-     *
      * @return \Closure Closure
+     * @throws \Exception
      */
     private function getHandler($class, $optionName)
     {

--- a/tests/Config/Loader/ClassLoader/FormatterLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/FormatterLoaderTest.php
@@ -43,6 +43,7 @@ class FormatterLoaderTest extends \PHPUnit_Framework_TestCase
      *
      * @param  string $class Class name the handler applies to
      * @param  string $optionName Option name
+     *
      * @return \Closure Closure
      */
     private function getHandler($class, $optionName)
@@ -69,10 +70,10 @@ class FormatterLoaderTest extends \PHPUnit_Framework_TestCase
      * Tests that calling the given Closure will trigger a method call with the given param
      * in the given class
      *
-     * @param  string   $class      Class name
-     * @param  string   $methodName Method name
-     * @param  mixed    $methodArg  Parameter passed to the closure
-     * @param  \Closure $closure    Closure to call
+     * @param  string $class Class name
+     * @param  string $methodName Method name
+     * @param  mixed $methodArg Parameter passed to the closure
+     * @param  \Closure $closure Closure to call
      */
     private function doTestMethodCalledInHandler($class, $methodName, $methodArg, \Closure $closure)
     {
@@ -109,7 +110,7 @@ class FormatterLoaderTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array(
-                '\Monolog\Formatter\LineFormatter',  // Class name
+                'Monolog\Formatter\LineFormatter',   // Class name
                 'includeStacktraces',                // Option name
                 true,                                // Option test value
                 'includeStacktraces'                 // Name of the method called by your handler
@@ -119,7 +120,12 @@ class FormatterLoaderTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Test the extra option handlers
+     * @see doTestMethodCalledInHandler
      *
+     * @param  string $class Class name
+     * @param  string $optionName Option name
+     * @param  mixed $optionValue Option value
+     * @param  string $calledMethodName Expected called method name
      * @dataProvider handlerParamsProvider
      */
     public function testHandlers($class, $optionName, $optionValue, $calledMethodName)

--- a/tests/Config/Loader/ClassLoader/FormatterLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/FormatterLoaderTest.php
@@ -11,13 +11,14 @@
 namespace Cascade\Tests\Config\Loader\ClassLoader;
 
 use Cascade\Config\Loader\ClassLoader\FormatterLoader;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class FormatterLoaderTest
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class FormatterLoaderTest extends \PHPUnit_Framework_TestCase
+class FormatterLoaderTest extends TestCase
 {
     /**
      * Set up function

--- a/tests/Config/Loader/ClassLoader/HandlerLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/HandlerLoaderTest.php
@@ -54,7 +54,7 @@ class HandlerLoaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testHandlerLoaderWithInvalidFormatter()
     {
@@ -67,7 +67,7 @@ class HandlerLoaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testHandlerLoaderWithInvalidProcessor()
     {
@@ -84,7 +84,7 @@ class HandlerLoaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testHandlerLoaderWithInvalidHandler()
     {
@@ -102,7 +102,7 @@ class HandlerLoaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testHandlerLoaderWithInvalidHandlers()
     {
@@ -128,8 +128,8 @@ class HandlerLoaderTest extends \PHPUnit_Framework_TestCase
      *
      * @param  string $class Class name the handler applies to
      * @param  string $optionName Option name
-     *
      * @return \Closure Closure
+     * @throws \Exception
      */
     private function getHandler($class, $optionName)
     {

--- a/tests/Config/Loader/ClassLoader/HandlerLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/HandlerLoaderTest.php
@@ -27,7 +27,7 @@ class HandlerLoaderTest extends \PHPUnit_Framework_TestCase
             // Empty function
         };
         $original = $options = array(
-            'class' => '\Monolog\Handler\TestHandler',
+            'class' => 'Monolog\Handler\TestHandler',
             'level' => 'DEBUG',
             'formatter' => 'test_formatter',
             'processors' => array('test_processor_1', 'test_processor_2')
@@ -128,6 +128,7 @@ class HandlerLoaderTest extends \PHPUnit_Framework_TestCase
      *
      * @param  string $class Class name the handler applies to
      * @param  string $optionName Option name
+     *
      * @return \Closure Closure
      */
     private function getHandler($class, $optionName)
@@ -154,10 +155,10 @@ class HandlerLoaderTest extends \PHPUnit_Framework_TestCase
      * Tests that calling the given Closure will trigger a method call with the given param
      * in the given class
      *
-     * @param  string   $class      Class name
-     * @param  string   $methodName Method name
-     * @param  mixed    $methodArg  Parameter passed to the closure
-     * @param  \Closure $closure    Closure to call
+     * @param  string $class Class name
+     * @param  string $methodName Method name
+     * @param  mixed $methodArg Parameter passed to the closure
+     * @param  \Closure $closure Closure to call
      */
     private function doTestMethodCalledInHandler($class, $methodName, $methodArg, \Closure $closure)
     {
@@ -216,6 +217,10 @@ class HandlerLoaderTest extends \PHPUnit_Framework_TestCase
     /**
      * Test the extra option handlers
      *
+     * @param  string $class Class name
+     * @param  string $optionName Option name
+     * @param  mixed $optionValue Option value
+     * @param  string $calledMethodName Expected called method name
      * @dataProvider handlerParamsProvider
      */
     public function testHandlers($class, $optionName, $optionValue, $calledMethodName)

--- a/tests/Config/Loader/ClassLoader/HandlerLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/HandlerLoaderTest.php
@@ -11,6 +11,9 @@
 namespace Cascade\Tests\Config\Loader\ClassLoader;
 
 use Monolog\Formatter\LineFormatter;
+use Monolog\Processor\MemoryUsageProcessor;
+use Monolog\Processor\WebProcessor;
+use PHPUnit\Framework\TestCase;
 
 use Cascade\Config\Loader\ClassLoader\HandlerLoader;
 
@@ -19,7 +22,7 @@ use Cascade\Config\Loader\ClassLoader\HandlerLoader;
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class HandlerLoaderTest extends \PHPUnit_Framework_TestCase
+class HandlerLoaderTest extends TestCase
 {
     public function testHandlerLoader()
     {
@@ -244,8 +247,8 @@ class HandlerLoaderTest extends \PHPUnit_Framework_TestCase
     {
         $options = array();
 
-        $mockProcessor1 = '123';
-        $mockProcessor2 = '456';
+        $mockProcessor1 = $this->createMock(WebProcessor::class);
+        $mockProcessor2 = $this->createMock(MemoryUsageProcessor::class);
         $processorsArray = array($mockProcessor1, $mockProcessor2);
 
         // Setup mock and expectations

--- a/tests/Config/Loader/ClassLoader/LoggerLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/LoggerLoaderTest.php
@@ -57,7 +57,7 @@ class LoggerLoaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testResolveHandlersWithMismatch()
     {
@@ -96,7 +96,7 @@ class LoggerLoaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testResolveProcessorsWithMismatch()
     {

--- a/tests/Config/Loader/ClassLoader/LoggerLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/LoggerLoaderTest.php
@@ -13,6 +13,7 @@ namespace Cascade\Tests\Config\Loader\ClassLoader;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use Monolog\Registry;
+use PHPUnit\Framework\TestCase;
 
 use Cascade\Config\Loader\ClassLoader\LoggerLoader;
 
@@ -21,7 +22,7 @@ use Cascade\Config\Loader\ClassLoader\LoggerLoader;
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class LoggerLoaderTest extends \PHPUnit_Framework_TestCase
+class LoggerLoaderTest extends TestCase
 {
     /**
      * Tear down function

--- a/tests/Config/Loader/ClassLoader/ProcessorLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/ProcessorLoaderTest.php
@@ -10,8 +10,9 @@
  */
 namespace Cascade\Tests\Config\Loader\ClassLoader;
 
-use Cascade\Config\Loader\ClassLoader\ProcessorLoader;
 use Monolog\Processor\WebProcessor;
+
+use Cascade\Config\Loader\ClassLoader\ProcessorLoader;
 
 /**
  * Class ProcessorLoaderTest
@@ -23,7 +24,7 @@ class ProcessorLoaderTest extends \PHPUnit_Framework_TestCase
     public function testProcessorLoader()
     {
         $options = array(
-            'class' => '\Monolog\Processor\WebProcessor'
+            'class' => 'Monolog\Processor\WebProcessor'
         );
         $processors = array(new WebProcessor());
         $loader = new ProcessorLoader($options, $processors);

--- a/tests/Config/Loader/ClassLoader/ProcessorLoaderTest.php
+++ b/tests/Config/Loader/ClassLoader/ProcessorLoaderTest.php
@@ -11,6 +11,7 @@
 namespace Cascade\Tests\Config\Loader\ClassLoader;
 
 use Monolog\Processor\WebProcessor;
+use PHPUnit\Framework\TestCase;
 
 use Cascade\Config\Loader\ClassLoader\ProcessorLoader;
 
@@ -19,7 +20,7 @@ use Cascade\Config\Loader\ClassLoader\ProcessorLoader;
  *
  * @author Kate Burdon <kburdon@tableau.com>
  */
-class ProcessorLoaderTest extends \PHPUnit_Framework_TestCase
+class ProcessorLoaderTest extends TestCase
 {
     public function testProcessorLoader()
     {

--- a/tests/Config/Loader/ClassLoader/Resolver/ConstructorResolverTest.php
+++ b/tests/Config/Loader/ClassLoader/Resolver/ConstructorResolverTest.php
@@ -13,6 +13,8 @@ namespace Cascade\Tests\Config\Loader\ClassLoader\Resolver;
 use Cascade\Util;
 use Cascade\Config\Loader\ClassLoader\Resolver\ConstructorResolver;
 
+use Symfony;
+
 /**
  * Class ConstructorResolverTest
  *
@@ -55,7 +57,7 @@ class ConstructorResolverTest extends \PHPUnit_Framework_TestCase
     /**
      * Return the contructor args of the reflected class
      *
-     * @return ReflectionParameter[] array of params
+     * @return \ReflectionParameter[] array of params
      */
     protected function getConstructorArgs()
     {

--- a/tests/Config/Loader/ClassLoader/Resolver/ConstructorResolverTest.php
+++ b/tests/Config/Loader/ClassLoader/Resolver/ConstructorResolverTest.php
@@ -12,6 +12,8 @@ namespace Cascade\Tests\Config\Loader\ClassLoader\Resolver;
 
 use Cascade\Util;
 use Cascade\Config\Loader\ClassLoader\Resolver\ConstructorResolver;
+use PHPUnit\Framework\TestCase;
+use Cascade\Tests\Fixtures\SampleClass;
 
 use Symfony;
 
@@ -20,7 +22,7 @@ use Symfony;
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class ConstructorResolverTest extends \PHPUnit_Framework_TestCase
+class ConstructorResolverTest extends TestCase
 {
     /**
      * Reflection class for which you want to resolve extra options

--- a/tests/Config/Loader/ClassLoader/Resolver/ConstructorResolverTest.php
+++ b/tests/Config/Loader/ClassLoader/Resolver/ConstructorResolverTest.php
@@ -10,10 +10,9 @@
  */
 namespace Cascade\Tests\Config\Loader\ClassLoader\Resolver;
 
-use Cascade\Config\Loader\ClassLoader\Resolver\ConstructorResolver;
-use Cascade\Tests\Fixtures\SampleClass;
-
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+
+use Cascade\Config\Loader\ClassLoader\Resolver\ConstructorResolver;
 
 /**
  * Class ConstructorResolverTest
@@ -24,14 +23,12 @@ class ConstructorResolverTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * Reflection class for which you want to resolve extra options
-     *
      * @var \ReflectionClass
      */
     protected $reflected = null;
 
     /**
      * Constructor Resolver
-     *
      * @var ConstructorResolver
      */
     protected $resolver = null;
@@ -77,7 +74,7 @@ class ConstructorResolverTest extends \PHPUnit_Framework_TestCase
     /**
      * Test that constructor args were pulled properly
      *
-     * Notie that we need to deuplicate the CamelCase conversion here for old
+     * Note that we need to deuplicate the CamelCase conversion here for old
      * fashioned classes
      */
     public function testInitConstructorArgs()
@@ -111,10 +108,11 @@ class ConstructorResolverTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Data provider for testResolve
-     * @return array of arrays with expected resolved values and options used as input
      *
      * The order of the input options does not matter and is somewhat random. The resolution
      * should reconcile those options and match them up with the contructor param position
+     *
+     * @return array of arrays with expected resolved values and options used as input
      */
     public function optionsProvider()
     {
@@ -145,19 +143,23 @@ class ConstructorResolverTest extends \PHPUnit_Framework_TestCase
     /**
      * Test resolving with valid options
      *
+     * @param array $expectedResolvedOptions Array of expected resolved options
+     * (i.e. parsed and validated)
+     * @param  array $options Array of raw options
      * @dataProvider optionsProvider
      */
-    public function testResolve($expectedResolvedOptions, $options)
+    public function testResolve(array $expectedResolvedOptions, array $options)
     {
         $this->assertEquals($expectedResolvedOptions, $this->resolver->resolve($options));
     }
 
     /**
-     * Data provider for testResolveWithInvalidOptions
-     * @return array of arrays with expected resolved values and options used as input
+     * Data provider for testResolveWithInvalidOptions.
      *
      * The order of the input options does not matter and is somewhat random. The resolution
      * should reconcile those options and match them up with the contructor param position
+     *
+     * @return array of arrays with expected resolved values and options used as input
      */
     public function missingOptionsProvider()
     {
@@ -177,22 +179,24 @@ class ConstructorResolverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test resolving with invalid options
+     * Test resolving with missing/incomplete options. It should throw an exception.
      *
+     * @param  array $incompleteOptions Array of invalid options
      * @dataProvider missingOptionsProvider
      * @expectedException Symfony\Component\OptionsResolver\Exception\MissingOptionsException
      */
-    public function testResolveWithMissingOptions($invalidOptions)
+    public function testResolveWithMissingOptions(array $incompleteOptions)
     {
-        $this->resolver->resolve($invalidOptions);
+        $this->resolver->resolve($incompleteOptions);
     }
 
     /**
      * Data provider for testResolveWithInvalidOptions
-     * @return array of arrays with expected resolved values and options used as input
      *
      * The order of the input options does not matter and is somewhat random. The resolution
      * should reconcile those options and match them up with the contructor param position
+     *
+     * @return array of arrays with expected resolved values and options used as input
      */
     public function invalidOptionsProvider()
     {
@@ -214,8 +218,9 @@ class ConstructorResolverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test resolving with invalid options
+     * Test resolving with invalid options. It should throw an exception.
      *
+     * @param  array $invalidOptions Array of invalid options
      * @dataProvider invalidOptionsProvider
      * @expectedException Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException
      */

--- a/tests/Config/Loader/ClassLoader/Resolver/ConstructorResolverTest.php
+++ b/tests/Config/Loader/ClassLoader/Resolver/ConstructorResolverTest.php
@@ -10,8 +10,7 @@
  */
 namespace Cascade\Tests\Config\Loader\ClassLoader\Resolver;
 
-use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
-
+use Cascade\Util;
 use Cascade\Config\Loader\ClassLoader\Resolver\ConstructorResolver;
 
 /**
@@ -80,10 +79,9 @@ class ConstructorResolverTest extends \PHPUnit_Framework_TestCase
     public function testInitConstructorArgs()
     {
         $expectedConstructorArgs = array();
-        $nameConverter = new CamelCaseToSnakeCaseNameConverter();
 
         foreach ($this->getConstructorArgs() as $param) {
-            $expectedConstructorArgs[$nameConverter->denormalize($param->getName())] = $param;
+            $expectedConstructorArgs[Util::snakeToCamelCase($param->getName())] = $param;
         }
         $this->assertEquals($expectedConstructorArgs, $this->resolver->getConstructorArgs());
     }

--- a/tests/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolverTest.php
+++ b/tests/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolverTest.php
@@ -12,6 +12,8 @@ namespace Cascade\Tests\Config\Loader\ClassLoader\Resolver;
 
 use Cascade\Config\Loader\ClassLoader\Resolver\ExtraOptionsResolver;
 
+use Symfony;
+
 /**
  * Class ExtraOptionsResolverTest
  *

--- a/tests/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolverTest.php
+++ b/tests/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolverTest.php
@@ -11,7 +11,6 @@
 namespace Cascade\Tests\Config\Loader\ClassLoader\Resolver;
 
 use Cascade\Config\Loader\ClassLoader\Resolver\ExtraOptionsResolver;
-use Cascade\Tests\Fixtures\SampleClass;
 
 /**
  * Class ExtraOptionsResolverTest
@@ -22,14 +21,12 @@ class ExtraOptionsResolverTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * Reflection class for which you want to resolve extra options
-     *
      * @var \ReflectionClass
      */
     protected $reflected = null;
 
     /**
      * ExtraOptions Resolver
-     *
      * @var ExtraOptionsResolver
      */
     protected $resolver = null;
@@ -97,9 +94,11 @@ class ExtraOptionsResolverTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Data provider for testResolveWithInvalidOptions
-     * @return array of arrays with expected resolved values and options used as input
      *
      * The order of the input options does not matter and is somewhat random. The resolution
+     * should reconcile those options and match them up with the closure param position
+     *
+     * @return array of arrays with expected resolved values and options used as input
      */
     public function optionsProvider()
     {
@@ -116,7 +115,6 @@ class ExtraOptionsResolverTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Test resolving with valid options
-     *
      */
     public function testResolveWithCustomOptionHandler()
     {
@@ -140,9 +138,11 @@ class ExtraOptionsResolverTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Data provider for testResolveWithInvalidOptions
-     * @return array of arrays with expected resolved values and options used as input
      *
      * The order of the input options does not matter and is somewhat random. The resolution
+     * should reconcile those options and match them up with the closure param position
+     *
+     * @return array of arrays with expected resolved values and options used as input
      */
     public function invalidOptionsProvider()
     {
@@ -162,8 +162,9 @@ class ExtraOptionsResolverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test resolving with invalid options
+     * Test resolving with invalid options. It should throw an exception.
      *
+     * @param  array $invalidOptions Array of invalid options
      * @dataProvider invalidOptionsProvider
      * @expectedException Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException
      */

--- a/tests/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolverTest.php
+++ b/tests/Config/Loader/ClassLoader/Resolver/ExtraOptionsResolverTest.php
@@ -13,13 +13,15 @@ namespace Cascade\Tests\Config\Loader\ClassLoader\Resolver;
 use Cascade\Config\Loader\ClassLoader\Resolver\ExtraOptionsResolver;
 
 use Symfony;
+use PHPUnit\Framework\TestCase;
+use Cascade\Tests\Fixtures\SampleClass;
 
 /**
  * Class ExtraOptionsResolverTest
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class ExtraOptionsResolverTest extends \PHPUnit_Framework_TestCase
+class ExtraOptionsResolverTest extends TestCase
 {
     /**
      * Reflection class for which you want to resolve extra options

--- a/tests/Config/Loader/ClassLoaderTest.php
+++ b/tests/Config/Loader/ClassLoaderTest.php
@@ -10,18 +10,15 @@
  */
 namespace Cascade\Tests\Config\Loader;
 
-use Monolog\Handler\TestHandler;
-use Monolog\Logger;
-use Monolog\Registry;
-
 use Cascade\Config\Loader\ClassLoader;
-use Cascade\Tests\Fixtures\SampleClass;
 use Cascade\Tests\Fixtures\DependentClass;
+use Cascade\Tests\Fixtures\SampleClass;
 
 /**
  * Class ClassLoaderTest
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ * @author Dom Morgan <dom@d3r.com>
  */
 class ClassLoaderTest extends \PHPUnit_Framework_TestCase
 {
@@ -68,7 +65,8 @@ class ClassLoaderTest extends \PHPUnit_Framework_TestCase
     /**
      * Testing the setClass method
      *
-     * @param  array $options array of options
+     * @param  array $options Array of options
+     * @param  string $expectedClass Expected classname of the instantiated object
      * @dataProvider dataFortestSetClass
      */
     public function testSetClass($options, $expectedClass)
@@ -149,8 +147,6 @@ class ClassLoaderTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Test a nested class to load
-     *
-     * @author Dom Morgan <dom@d3r.com>
      */
     public function testLoadDependency()
     {

--- a/tests/Config/Loader/ClassLoaderTest.php
+++ b/tests/Config/Loader/ClassLoaderTest.php
@@ -10,6 +10,11 @@
  */
 namespace Cascade\Tests\Config\Loader;
 
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use Monolog\Registry;
+use PHPUnit\Framework\TestCase;
+
 use Cascade\Config\Loader\ClassLoader;
 use Cascade\Tests\Fixtures\DependentClass;
 use Cascade\Tests\Fixtures\SampleClass;
@@ -20,7 +25,7 @@ use Cascade\Tests\Fixtures\SampleClass;
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  * @author Dom Morgan <dom@d3r.com>
  */
-class ClassLoaderTest extends \PHPUnit_Framework_TestCase
+class ClassLoaderTest extends TestCase
 {
     /**
      * Set up function

--- a/tests/Config/Loader/FileLoader/FileLoaderAbstractTest.php
+++ b/tests/Config/Loader/FileLoader/FileLoaderAbstractTest.php
@@ -95,7 +95,7 @@ class FileLoaderAbstractTest extends \PHPUnit_Framework_TestCase
      * Test validating the extension
      *
      * @param boolean $expected Expected boolean value
-     * @param string filepath Filepath to validate
+     * @param string $filepath Filepath to validate
      * @dataProvider extensionsDataProvider
      */
     public function testValidateExtension($expected, $filepath)
@@ -152,7 +152,7 @@ class FileLoaderAbstractTest extends \PHPUnit_Framework_TestCase
     /**
      * Test loading an invalid file
      *
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      */
     public function testloadFileFromInvalidFile()
     {

--- a/tests/Config/Loader/FileLoader/FileLoaderAbstractTest.php
+++ b/tests/Config/Loader/FileLoader/FileLoaderAbstractTest.php
@@ -10,9 +10,9 @@
  */
 namespace Cascade\Tests\Config\Loader\FileLoader;
 
-use org\bovigo\vfs\vfsStream;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\FileLocatorInterface;
+use org\bovigo\vfs\vfsStream;
 
 use Cascade\Tests\Fixtures;
 
@@ -23,6 +23,10 @@ use Cascade\Tests\Fixtures;
  */
 class FileLoaderAbstractTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * Mock of extending Cascade\Config\Loader\FileLoader\FileLoaderAbstract
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
     protected $mock = null;
 
     public function setUp()
@@ -73,6 +77,7 @@ class FileLoaderAbstractTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Data provider for testGetSectionOf
+     *
      * @return array array with original value, section and expected value
      */
     public function extensionsDataProvider()
@@ -89,6 +94,8 @@ class FileLoaderAbstractTest extends \PHPUnit_Framework_TestCase
     /**
      * Test validating the extension
      *
+     * @param boolean $expected Expected boolean value
+     * @param string filepath Filepath to validate
      * @dataProvider extensionsDataProvider
      */
     public function testValidateExtension($expected, $filepath)
@@ -102,6 +109,7 @@ class FileLoaderAbstractTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Data provider for testGetSectionOf
+     *
      * @return array array wit original value, section and expected value
      */
     public function arrayDataProvider()
@@ -131,9 +139,12 @@ class FileLoaderAbstractTest extends \PHPUnit_Framework_TestCase
     /**
      * Test the getSectionOf function
      *
+     * @param array $array Array of options
+     * @param string $section Section key
+     * @param array $expected Expected array for the given section
      * @dataProvider arrayDataProvider
      */
-    public function testGetSectionOf($array, $section, $expected)
+    public function testGetSectionOf(array $array, $section, array $expected)
     {
         $this->assertSame($expected, $this->mock->getSectionOf($array, $section));
     }

--- a/tests/Config/Loader/FileLoader/FileLoaderAbstractTest.php
+++ b/tests/Config/Loader/FileLoader/FileLoaderAbstractTest.php
@@ -13,6 +13,7 @@ namespace Cascade\Tests\Config\Loader\FileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\FileLocatorInterface;
 use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
 
 use Cascade\Tests\Fixtures;
 
@@ -21,7 +22,7 @@ use Cascade\Tests\Fixtures;
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class FileLoaderAbstractTest extends \PHPUnit_Framework_TestCase
+class FileLoaderAbstractTest extends TestCase
 {
     /**
      * Mock of extending Cascade\Config\Loader\FileLoader\FileLoaderAbstract
@@ -33,7 +34,7 @@ class FileLoaderAbstractTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $fileLocatorMock = $this->getMock(
+        $fileLocatorMock = $this->createMock(
             'Symfony\Component\Config\FileLocatorInterface'
         );
 

--- a/tests/Config/Loader/FileLoader/JsonTest.php
+++ b/tests/Config/Loader/FileLoader/JsonTest.php
@@ -10,7 +10,6 @@
  */
 namespace Cascade\Tests\Config\Loader\FileLoader;
 
-use Cascade\Config\Loader\FileLoader\Json as JsonLoader;
 use Cascade\Tests\Fixtures;
 
 /**
@@ -20,6 +19,10 @@ use Cascade\Tests\Fixtures;
  */
 class JsonTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * JSON loader mock builder
+     * @var \PHPUnit_Framework_MockObject_MockBuilder
+     */
     protected $jsonLoader = null;
 
     public function setUp()
@@ -63,6 +66,7 @@ class JsonTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Data provider for testSupportsWithInvalidResource
+     *
      * @return array array non-string values
      */
     public function notStringDataProvider()
@@ -74,16 +78,15 @@ class JsonTest extends \PHPUnit_Framework_TestCase
             array(123.456),
             array(null),
             array(new \stdClass),
-            // array(function () {
-            // })
-            // cannot test Closure type because of PhpUnit
-            // @see https://github.com/sebastianbergmann/phpunit/issues/451
+            array(function () {
+            })
         );
     }
 
     /**
      * Test loading resources supported by the JsonLoader
      *
+     * @param mixed $invalidResource Invalid resource value
      * @dataProvider notStringDataProvider
      */
     public function testSupportsWithInvalidResource($invalidResource)

--- a/tests/Config/Loader/FileLoader/JsonTest.php
+++ b/tests/Config/Loader/FileLoader/JsonTest.php
@@ -11,13 +11,14 @@
 namespace Cascade\Tests\Config\Loader\FileLoader;
 
 use Cascade\Tests\Fixtures;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class JsonTest
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class JsonTest extends \PHPUnit_Framework_TestCase
+class JsonTest extends TestCase
 {
     /**
      * JSON loader mock builder
@@ -29,7 +30,7 @@ class JsonTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $fileLocatorMock = $this->getMock(
+        $fileLocatorMock = $this->createMock(
             'Symfony\Component\Config\FileLocatorInterface'
         );
 

--- a/tests/Config/Loader/FileLoader/PhpArrayTest.php
+++ b/tests/Config/Loader/FileLoader/PhpArrayTest.php
@@ -7,9 +7,9 @@
  */
 namespace Cascade\Tests\Config\Loader\FileLoader;
 
-use Cascade\Config\Loader\FileLoader\PhpArray as ArrayLoader;
-use Cascade\Tests\Fixtures;
 use Symfony\Component\Config\FileLocator;
+
+use Cascade\Config\Loader\FileLoader\PhpArray as ArrayLoader;
 
 /**
  * Class PhpArrayTest
@@ -33,13 +33,13 @@ class PhpArrayTest extends \PHPUnit_Framework_TestCase
 
     public function testSupportsPhpFile()
     {
-        $this->assertTrue($this->loader->supports(__DIR__ . '/../../../Fixtures/fixture_config.php'));
+        $this->assertTrue($this->loader->supports(__DIR__.'/../../../Fixtures/fixture_config.php'));
     }
 
     public function testDoesNotSupportNonPhpFiles()
     {
         $this->assertFalse($this->loader->supports('foo'));
-        $this->assertFalse($this->loader->supports(__DIR__ . '/../../../Fixtures/fixture_config.json'));
+        $this->assertFalse($this->loader->supports(__DIR__.'/../../../Fixtures/fixture_config.json'));
     }
 
     /**
@@ -47,14 +47,14 @@ class PhpArrayTest extends \PHPUnit_Framework_TestCase
      */
     public function testThrowsExceptionWhenLoadingFileIfDoesNotReturnValidPhpArray()
     {
-        $this->loader->load(__DIR__ . '/../../../Fixtures/fixture_invalid_config.php');
+        $this->loader->load(__DIR__.'/../../../Fixtures/fixture_invalid_config.php');
     }
 
     public function testLoadsPhpArrayConfigFromFile()
     {
         $this->assertSame(
-            include __DIR__ . '/../../../Fixtures/fixture_config.php',
-            $this->loader->load(__DIR__ . '/../../../Fixtures/fixture_config.php')
+            include __DIR__.'/../../../Fixtures/fixture_config.php',
+            $this->loader->load(__DIR__.'/../../../Fixtures/fixture_config.php')
         );
     }
 }

--- a/tests/Config/Loader/FileLoader/PhpArrayTest.php
+++ b/tests/Config/Loader/FileLoader/PhpArrayTest.php
@@ -8,13 +8,14 @@
 namespace Cascade\Tests\Config\Loader\FileLoader;
 
 use Symfony\Component\Config\FileLocator;
+use PHPUnit\Framework\TestCase;
 
 use Cascade\Config\Loader\FileLoader\PhpArray as ArrayLoader;
 
 /**
  * Class PhpArrayTest
  */
-class PhpArrayTest extends \PHPUnit_Framework_TestCase
+class PhpArrayTest extends TestCase
 {
     /**
      * @var ArrayLoader

--- a/tests/Config/Loader/FileLoader/YamlTest.php
+++ b/tests/Config/Loader/FileLoader/YamlTest.php
@@ -12,7 +12,6 @@ namespace Cascade\Tests\Config\Loader\FileLoader;
 
 use Symfony\Component\Yaml\Yaml as YamlParser;
 
-use Cascade\Config\Loader\FileLoader\Yaml as YamlLoader;
 use Cascade\Tests\Fixtures;
 
 /**
@@ -22,6 +21,10 @@ use Cascade\Tests\Fixtures;
  */
 class YamlTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * Yaml loader mock builder
+     * @var \PHPUnit_Framework_MockObject_MockBuilder
+     */
     protected $yamlLoader = null;
 
     public function setUp()
@@ -86,6 +89,7 @@ class YamlTest extends \PHPUnit_Framework_TestCase
     /**
      * Test loading resources supported by the YamlLoader
      *
+     * @param mixed $invalidResource Invalid resource value
      * @dataProvider notStringDataProvider
      */
     public function testSupportsWithInvalidResource($invalidResource)

--- a/tests/Config/Loader/FileLoader/YamlTest.php
+++ b/tests/Config/Loader/FileLoader/YamlTest.php
@@ -13,13 +13,14 @@ namespace Cascade\Tests\Config\Loader\FileLoader;
 use Symfony\Component\Yaml\Yaml as YamlParser;
 
 use Cascade\Tests\Fixtures;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class YamlTest
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class YamlTest extends \PHPUnit_Framework_TestCase
+class YamlTest extends TestCase
 {
     /**
      * Yaml loader mock builder
@@ -31,7 +32,7 @@ class YamlTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $fileLocatorMock = $this->getMock(
+        $fileLocatorMock = $this->createMock(
             'Symfony\Component\Config\FileLocatorInterface'
         );
 

--- a/tests/Config/Loader/PhpArrayTest.php
+++ b/tests/Config/Loader/PhpArrayTest.php
@@ -20,6 +20,10 @@ use Cascade\Tests\Fixtures;
  */
 class PhpArrayTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * Array loader object
+     * @var ArrayLoader
+     */
     protected $arrayLoader = null;
 
     public function setUp()
@@ -46,6 +50,7 @@ class PhpArrayTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Data provider for testSupportsWithInvalidResource
+     *
      * @return array array of non-array values
      */
     public function notStringDataProvider()
@@ -57,16 +62,15 @@ class PhpArrayTest extends \PHPUnit_Framework_TestCase
             array(123.456),
             array(null),
             array(new \stdClass),
-            // array(function () {
-            // })
-            // cannot test Closure type because of PhpUnit
-            // @see https://github.com/sebastianbergmann/phpunit/issues/451
+            array(function () {
+            })
         );
     }
 
     /**
      * Test loading resources supported by the YamlLoader
      *
+     * @param mixed $invalidResource Invalid resource value
      * @dataProvider notStringDataProvider
      */
     public function testSupportsWithInvalidResource($invalidResource)

--- a/tests/Config/Loader/PhpArrayTest.php
+++ b/tests/Config/Loader/PhpArrayTest.php
@@ -12,13 +12,14 @@ namespace Cascade\Tests\Config\Loader;
 
 use Cascade\Config\Loader\PhpArray as ArrayLoader;
 use Cascade\Tests\Fixtures;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class PhpArrayTest
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class PhpArrayTest extends \PHPUnit_Framework_TestCase
+class PhpArrayTest extends TestCase
 {
     /**
      * Array loader object

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -10,8 +10,6 @@
  */
 namespace Cascade\Tests;
 
-use Monolog\Handler\TestHandler;
-use Monolog\Logger;
 use Monolog\Registry;
 
 use Cascade\Config;

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -11,6 +11,7 @@
 namespace Cascade\Tests;
 
 use Monolog\Registry;
+use PHPUnit\Framework\TestCase;
 
 use Cascade\Config;
 use Cascade\Tests\Fixtures;
@@ -20,7 +21,7 @@ use Cascade\Tests\Fixtures;
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
  */
-class ConfigTest extends \PHPUnit_Framework_TestCase
+class ConfigTest extends TestCase
 {
     /**
      * Testing contructor and load functions

--- a/tests/Fixtures.php
+++ b/tests/Fixtures.php
@@ -43,6 +43,16 @@ class Fixtures
     }
 
     /**
+     * Return a config as Yaml
+     *
+     * @return string Yaml config
+     */
+    public static function getYamlConfig()
+    {
+        return file_get_contents(self::fixtureDir().'/fixture_config.yml');
+    }
+
+    /**
      * Return the fixture sample Yaml file
      *
      * @return string Path to a sample yaml file
@@ -74,6 +84,16 @@ class Fixtures
     public static function getJsonConfigFile()
     {
         return self::fixtureDir().'/fixture_config.json';
+    }
+
+    /**
+     * Return a config as JSON
+     *
+     * @return string JSON config
+     */
+    public static function getJsonConfig()
+    {
+        return file_get_contents(self::fixtureDir().'/fixture_config.json');
     }
 
     /**
@@ -109,6 +129,16 @@ class Fixtures
     public static function getSampleString()
     {
         return " some string with new \n\n lines and white spaces \n\n";
+    }
+
+    /**
+     * Return the fixture PHP array config file
+     *
+     * @return string Path to PHP array config file
+     */
+    public static function getPhpArrayConfigFile()
+    {
+        return self::fixtureDir().'/fixture_config.php';
     }
 
     /**

--- a/tests/Fixtures.php
+++ b/tests/Fixtures.php
@@ -14,7 +14,8 @@ class Fixtures
 {
     /**
      * Return the fixture directory
-     * @return string ficture directory
+     *
+     * @return string Fixture directory
      */
     public static function fixtureDir()
     {
@@ -23,7 +24,8 @@ class Fixtures
 
     /**
      * Return a path to a non existing file
-     * @return string wrong file path
+     *
+     * @return string Wrong file path
      */
     public static function getInvalidFile()
     {
@@ -32,7 +34,8 @@ class Fixtures
 
     /**
      * Return the fixture Yaml config file
-     * @return string path to yaml config file
+     *
+     * @return string Path to yaml config file
      */
     public static function getYamlConfigFile()
     {
@@ -41,7 +44,8 @@ class Fixtures
 
     /**
      * Return the fixture sample Yaml file
-     * @return string path to a sample yaml file
+     *
+     * @return string Path to a sample yaml file
      */
     public static function getSampleYamlFile()
     {
@@ -50,7 +54,8 @@ class Fixtures
 
     /**
      * Return the fixture sample Yaml string
-     * @return string sample yaml string
+     *
+     * @return string Sample yaml string
      */
     public static function getSampleYamlString()
     {
@@ -63,7 +68,8 @@ class Fixtures
 
     /**
      * Return the fixture JSON config file
-     * @return string path to JSON config file
+     *
+     * @return string Path to JSON config file
      */
     public static function getJsonConfigFile()
     {
@@ -72,7 +78,8 @@ class Fixtures
 
     /**
      * Return the fixture sample JSON file
-     * @return string path to a sample JSON file
+     *
+     * @return string Path to a sample JSON file
      */
     public static function getSampleJsonFile()
     {
@@ -81,7 +88,8 @@ class Fixtures
 
     /**
      * Return the fixture sample JSON string
-     * @return string sample JSON string
+     *
+     * @return string Sample JSON string
      */
     public static function getSampleJsonString()
     {
@@ -95,7 +103,8 @@ class Fixtures
 
     /**
      * Return a sample string
-     * @return string sample string
+     *
+     * @return string Sample string
      */
     public static function getSampleString()
     {
@@ -104,7 +113,8 @@ class Fixtures
 
     /**
      * Return a config array
-     * @return array config array
+     *
+     * @return array Config array
      */
     public static function getPhpArrayConfig()
     {
@@ -113,7 +123,8 @@ class Fixtures
 
     /**
      * Return a sample array
-     * @return array sample array
+     *
+     * @return array Sample array
      */
     public static function getSamplePhpArray()
     {

--- a/tests/Fixtures/DependentClass.php
+++ b/tests/Fixtures/DependentClass.php
@@ -11,36 +11,35 @@
 namespace Cascade\Tests\Fixtures;
 
 /**
- * Class SampleClass
+ * Class DependentClass
  *
  * @author Raphael Antonmattei <rantonmattei@theorchard.com>
+ * @author Dom Morgan <dom@d3r.com>
  */
 class DependentClass
 {
     /**
      * An object dependency
-     * @var Cascade\Tests\Fixtures\SampleClass
+     * @var SampleClass
      */
     private $dependency;
 
     /**
      * Constructor
      *
-     * @param mixed $mandatory Some mandatory param
-     * @param string $optionalA Some optional param
+     * @param SampleClass $dependency Some sample object
      */
-    public function __construct(
-        SampleClass $dependency
-    ) {
+    public function __construct(SampleClass $dependency)
+    {
         $this->setDependency($dependency);
     }
 
     /**
      * Set the object dependency
      *
-     * @param Cascade\Tests\Fixtures\SampleClass $dependency Some value
+     * @param SampleClass $dependency Some sample object
      */
-    public function setDependency($dependency)
+    public function setDependency(SampleClass $dependency)
     {
         $this->dependency = $dependency;
     }

--- a/tests/Fixtures/SampleClass.php
+++ b/tests/Fixtures/SampleClass.php
@@ -65,6 +65,7 @@ class SampleClass
      * @param mixed $mandatory Some mandatory param
      * @param string $optionalA Some optional param
      * @param string $optionalB Some other optional param
+     * @param string $optional_snake Some optional snake param
      */
     public function __construct(
         $mandatory,

--- a/tests/Fixtures/SampleClass.php
+++ b/tests/Fixtures/SampleClass.php
@@ -88,7 +88,7 @@ class SampleClass
     /**
      * Function that sets the optionalA member
      *
-     * @param  mixed $value some value
+     * @param  mixed $value Some value
      */
     public function optionalA($value)
     {
@@ -98,7 +98,7 @@ class SampleClass
     /**
      * Function that sets the optionalX member
      *
-     * @param  mixed $value some value
+     * @param  mixed $value Some value
      */
     public function optionalX($value)
     {
@@ -108,7 +108,7 @@ class SampleClass
     /**
      * Function that sets the hello member
      *
-     * @param  mixed $value some value
+     * @param  mixed $value Some value
      */
     public function setHello($value)
     {
@@ -118,7 +118,7 @@ class SampleClass
     /**
      * Function that sets the there member
      *
-     * @param  mixed $value some value
+     * @param  mixed $value Some value
      */
     public function setThere($value)
     {

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Cascade\Tests;
+
+use Cascade\Util;
+
+/**
+ * Class ConfigTest
+ *
+ * @author Deniz Dogan <deniz@dogan.se>
+ */
+class UtilTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSnakeToCamelCase()
+    {
+        // non-strings
+        $this->assertSame(null, Util::snakeToCamelCase(null));
+        $this->assertSame(null, Util::snakeToCamelCase(array()));
+        $this->assertSame(null, Util::snakeToCamelCase(1));
+
+        // strings
+        $this->assertSame('', Util::snakeToCamelCase(''));
+        $this->assertSame('foo', Util::snakeToCamelCase('foo'));
+        $this->assertSame('fooBar', Util::snakeToCamelCase('foo_bar'));
+        $this->assertSame('fooBarBaz', Util::snakeToCamelCase('foo_bar_baz'));
+
+        // weird strings
+        $this->assertSame('_', Util::snakeToCamelCase('_'));
+        $this->assertSame('__', Util::snakeToCamelCase('___'));
+        $this->assertSame('_ _', Util::snakeToCamelCase('_ _'));
+        $this->assertSame('x_', Util::snakeToCamelCase('X__'));
+        $this->assertSame('_X', Util::snakeToCamelCase('__X'));
+    }
+}

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -4,12 +4,14 @@ namespace Cascade\Tests;
 
 use Cascade\Util;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class ConfigTest
  *
  * @author Deniz Dogan <deniz@dogan.se>
  */
-class UtilTest extends \PHPUnit_Framework_TestCase
+class UtilTest extends TestCase
 {
     public function testSnakeToCamelCase()
     {


### PR DESCRIPTION
We need to support Monolog v. 2 in order to update the dependencies of LinioPay/API and LinioPay/Vault.

In order to do this, we need this package (monolog-cascade) to also support Monolog v. 2. After shifting the version on the composer.json, and running the php unit tests, we have some work ahead:

- [X] Rebase to the latest version of the original package `theorchard/monolog-cascade`
- [X] Upgrade tests to use the new PHP Unit base class (thanks @MarioDevment)
- [X] Fix mocks conflicting with the new HandlerLoader searching for a processor as an object not string (thanks again @MarioDevment)