### PR TITLE
fix: array access with curly braces deprecation in PHP 7.4

### DIFF
--- a/src/Config/Loader/FileLoader/Json.php
+++ b/src/Config/Loader/FileLoader/Json.php
@@ -49,7 +49,7 @@ class Json extends FileLoaderAbstract
     {
         return (
             !empty($string) &&
-            ($string{0} === '[' || $string{0} === '{')
+            ($string[0] === '[' || $string[0] === '{')
         );
     }
 


### PR DESCRIPTION
Quick fix to get this library working on PHP 7.4:
 - Array access with curly braces is deprecated